### PR TITLE
Temporal use cases

### DIFF
--- a/src/drools/ruleset.py
+++ b/src/drools/ruleset.py
@@ -60,6 +60,7 @@ class Matches:
 class Ruleset:
     name: str
     serialized_ruleset: str
+    pseudo_clock: bool = False
     _rules: dict = field(init=False, repr=False, default_factory=dict)
     _session_id: int = field(init=False, repr=False, default=None)
     _api: int = field(
@@ -83,7 +84,9 @@ class Ruleset:
         if self._session_id:
             return self._session_id
 
-        self._session_id = self._api.createRuleset(self.serialized_ruleset)
+        self._session_id = self._api.createRulesetWithOptions(
+            self.serialized_ruleset, self.pseudo_clock
+        )
         return self._session_id
 
     def end_session(self) -> None:
@@ -107,6 +110,9 @@ class Ruleset:
         return self._process_response(
             self._api.retractFact(self._session_id, serialized_fact)
         )
+
+    def advance_time(self, amount: int, units: str):
+        return self._api.advanceTime(self._session_id, amount, units)
 
     def get_pending_events(self):
         pass

--- a/tests/asts/test_once_within_ast.yml
+++ b/tests/asts/test_once_within_ast.yml
@@ -1,0 +1,27 @@
+- RuleSet:
+    hosts:
+    - localhost
+    name: Match rules once within a certain time
+    rules:
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - IsDefinedExpression:
+              Event: i
+        enabled: true
+        name: r1
+        once_within: 10 seconds
+        unique_attributes:
+        - event.meta.host
+    sources:
+    - EventSource:
+        name: range
+        source_args:
+          delay: 1
+          limit: 50
+        source_filters: []
+        source_name: range

--- a/tests/asts/test_time_window_ast.yml
+++ b/tests/asts/test_time_window_ast.yml
@@ -1,0 +1,27 @@
+- RuleSet:
+    hosts:
+    - localhost
+    name: All events have to occur within a time window
+    rules:
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - IsDefinedExpression:
+              Event: i
+          - IsDefinedExpression:
+              Event: j
+        enabled: true
+        name: r1
+        time_window: 10 seconds
+    sources:
+    - EventSource:
+        name: range
+        source_args:
+          delay: 1
+          limit: 50
+        source_filters: []
+        source_name: range


### PR DESCRIPTION
1. once_within with unique_attributes When an event storm happens we only process 1 event within a time window.
2. time_window When multiple events have to be checked, they need to be fulfilled within a time window.

The example values of once_within and time_window can be

* 10 milliseconds
* 10 seconds
* 10 minutes
* 10 hours
* 10 days
    