### PR TITLE
Added support for negation, floats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]

--- a/tests/asts/test_float_ast.yml
+++ b/tests/asts/test_float_ast.yml
@@ -1,0 +1,27 @@
+- RuleSet:
+    hosts:
+    - all
+    name: floats test
+    rules:
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Event: pi
+              rhs:
+                Float: 3.14159
+        enabled: true
+        name: r1
+    sources:
+    - EventSource:
+        name: generic
+        source_args:
+          payload:
+            pi: 3.14159
+        source_filters: []
+        source_name: generic

--- a/tests/asts/test_negation_ast.yml
+++ b/tests/asts/test_negation_ast.yml
@@ -1,0 +1,59 @@
+- RuleSet:
+    hosts:
+    - all
+    name: Negation tests
+    rules:
+    - Rule:
+        action:
+          Action:
+            action: print_event
+            action_args: {}
+        condition:
+          AllCondition:
+          - NegateExpression:
+              Event: b
+        enabled: true
+        name: r1
+    - Rule:
+        action:
+          Action:
+            action: print_event
+            action_args: {}
+        condition:
+          AllCondition:
+          - Event: bt
+        enabled: true
+        name: r2
+    - Rule:
+        action:
+          Action:
+            action: print_event
+            action_args: {}
+        condition:
+          AllCondition:
+          - NegateExpression:
+              OrExpression:
+                lhs:
+                  GreaterThanExpression:
+                    lhs:
+                      Event: i
+                    rhs:
+                      Integer: 50
+                rhs:
+                  LessThanExpression:
+                    lhs:
+                      Event: i
+                    rhs:
+                      Integer: 10
+        enabled: true
+        name: r3
+    sources:
+    - EventSource:
+        name: generic
+        source_args:
+          payload:
+          - b: false
+          - bt: true
+          - i: 10
+        source_filters: []
+        source_name: generic

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -730,3 +730,47 @@ def test_assert_event_with_contain():
     my_callback2.assert_called_with(result2)
     my_callback3.assert_called_with(result3)
     my_callback4.assert_called_with(result4)
+
+
+def test_assert_event_float():
+    test_data = load_ast("asts/test_float_ast.yml")
+
+    my_callback = mock.Mock()
+    result = Matches(data={"m": {"pi": 3.14159}})
+
+    ruleset_data = test_data[0]["RuleSet"]
+    rs = Ruleset(
+        name=ruleset_data["name"], serialized_ruleset=json.dumps(ruleset_data)
+    )
+    rs.add_rule(Rule("r1", my_callback))
+
+    rs.assert_event(json.dumps(dict(pi=3.14159)))
+    rs.end_session()
+    my_callback.assert_called_with(result)
+
+
+def test_assert_event_negation():
+    test_data = load_ast("asts/test_negation_ast.yml")
+
+    my_callback1 = mock.Mock()
+    my_callback2 = mock.Mock()
+    my_callback3 = mock.Mock()
+    result1 = Matches(data={"m": {"b": False}})
+    result2 = Matches(data={"m": {"bt": True}})
+    result3 = Matches(data={"m": {"i": 10}})
+
+    ruleset_data = test_data[0]["RuleSet"]
+    rs = Ruleset(
+        name=ruleset_data["name"], serialized_ruleset=json.dumps(ruleset_data)
+    )
+    rs.add_rule(Rule("r1", my_callback1))
+    rs.add_rule(Rule("r2", my_callback2))
+    rs.add_rule(Rule("r3", my_callback3))
+
+    rs.assert_event(json.dumps(dict(i=10)))
+    rs.assert_event(json.dumps(dict(b=False)))
+    rs.assert_event(json.dumps(dict(bt=True)))
+    rs.end_session()
+    my_callback1.assert_called_with(result1)
+    my_callback2.assert_called_with(result2)
+    my_callback3.assert_called_with(result3)


### PR DESCRIPTION
This PR adds support for floats
Negation
Standalone boolean fields in conditions
Example:

  condition: event.flag_enabled


Negation example:

 condition: not event.flag_enabled
 condition: not (event.i > 10 or event.i < 5)