### PR TITLE
Removed asyncio since its bundled in python3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
-"asyncio",
 "jpy",
 ]
 


### PR DESCRIPTION
Python3 already includes asyncio, we dont have to add it as a dependency