### PR TITLE
Load the jar from the jars directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]

--- a/tests/asts/test_select_with_same_event_ast.yml
+++ b/tests/asts/test_select_with_same_event_ast.yml
@@ -1,0 +1,44 @@
+- RuleSet:
+    hosts:
+    - all
+    name: Test is select
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: print_event
+            action_args: {}
+        condition:
+          AllCondition:
+          - AndExpression:
+              lhs:
+                EqualsExpression:
+                  lhs:
+                    Event: action
+                  rhs:
+                    String: go
+              rhs:
+                SelectExpression:
+                  lhs:
+                    Event: my_list
+                  rhs:
+                    operator:
+                      String: ==
+                    value:
+                      Event: my_int
+        enabled: true
+        name: Go
+    sources:
+    - EventSource:
+        name: generic
+        source_args:
+          payload:
+          - action: go
+            my_int: 3
+            my_list:
+            - 1
+            - 3
+            - 4
+            - 7
+        source_filters: []
+        source_name: generic

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -858,6 +858,7 @@ def test_assert_event_string_search():
         "asts/test_select_1_ast.yml",
         "asts/test_select_2_ast.yml",
         "asts/test_null_type_ast.yml",
+        "asts/test_select_with_same_event_ast.yml",
     ],
 )
 def test_integrated(rulebook):


### PR DESCRIPTION
This way we don't have to load jar by name.
We log the jar that is being used.
Fixed bug in select