### PR TITLE
[AAP-11113] Search in select was not working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.2.9"
+version = "0.3.0"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]

--- a/tests/asts/test_delayed_comparison_ast.yml
+++ b/tests/asts/test_delayed_comparison_ast.yml
@@ -1,0 +1,42 @@
+- RuleSet:
+    hosts:
+    - all
+    name: Delayed comparison
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: print_event
+            action_args:
+              pretty: true
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Event: action.type
+              rhs:
+                String: Delete
+          - SelectExpression:
+              lhs:
+                Event: friend_list.names
+              rhs:
+                operator:
+                  String: search
+                value:
+                  Events: m_0.action.friend_name
+        enabled: true
+        name: r1
+    sources:
+    - EventSource:
+        name: generic
+        source_args:
+          payload:
+          - friend_list:
+              names:
+              - fred
+              - barney
+          - action:
+              friend_name: fred
+              type: Delete
+        source_filters: []
+        source_name: generic

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -860,6 +860,7 @@ def test_assert_event_string_search():
         "asts/test_null_type_ast.yml",
         "asts/test_select_with_same_event_ast.yml",
         "asts/test_self_referential_ast.yml",
+        "asts/test_delayed_comparison_ast.yml",
     ],
 )
 def test_integrated(rulebook):


### PR DESCRIPTION
During a delayed comparison of events.m_0 we noticed that the select wasn't working.
https://issues.redhat.com/browse/AAP-11113

https://github.com/ansible/ansible-rulebook/issues/471