### PR TITLE
Partial match, events ttl, session stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]

--- a/src/drools/ruleset.py
+++ b/src/drools/ruleset.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import ClassVar, Dict
+from typing import ClassVar, Dict, List
 
 import jpyutil
 
@@ -173,6 +173,21 @@ class Ruleset:
             self._api.retractFact(self._session_id, serialized_fact)
         )
 
+    def retract_matching_facts(
+        self, serialized_fact: str, partial: bool, exclude_keys: List[str]
+    ):
+        return self._process_response(
+            self._api.retractMatchingFacts(
+                self._session_id, serialized_fact, partial, exclude_keys
+            )
+        )
+
+    def session_stats(self) -> Dict:
+        result = self._api.sessionStats(self._session_id)
+        if result:
+            return json.loads(result)
+        return {}
+
     def advance_time(self, amount: int, units: str):
         return self._api.advanceTime(self._session_id, amount, units)
 
@@ -294,8 +309,23 @@ def retract_fact(ruleset_name: str, serialized_fact: str):
     )
 
 
+def retract_matching_facts(
+    ruleset_name: str,
+    serialized_fact: str,
+    partial: bool,
+    exclude_keys: List[str],
+):
+    return RulesetCollection.get(ruleset_name).retract_matching_facts(
+        _to_json(serialized_fact), partial, exclude_keys
+    )
+
+
 def end_session(ruleset_name: str) -> Dict:
     return RulesetCollection.get(ruleset_name).end_session()
+
+
+def session_stats(ruleset_name: str) -> Dict:
+    return RulesetCollection.get(ruleset_name).session_stats()
 
 
 def get_facts(ruleset_name: str):

--- a/tests/asts/retract_matching_facts.yml
+++ b/tests/asts/retract_matching_facts.yml
@@ -1,0 +1,44 @@
+- RuleSet:
+    hosts:
+    - all
+    name: example
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: print_event
+            action_args:
+              pretty: true
+        condition:
+          AllCondition:
+          - GreaterThanExpression:
+              lhs:
+                Event: i
+              rhs:
+                Integer: 2
+          - GreaterThanExpression:
+              lhs:
+                Event: x
+              rhs:
+                Integer: 34
+        enabled: true
+        name: r1
+    - Rule:
+        actions:
+        - Action:
+            action: print_event
+            action_args:
+              pretty: true
+        condition:
+          AllCondition:
+          - IsNotDefinedExpression:
+              Event: i
+        enabled: true
+        name: r2
+    sources:
+    - EventSource:
+        name: range
+        source_args:
+          limit: 10
+        source_filters: []
+        source_name: range

--- a/tests/asts/test_default_events_ttl.yml
+++ b/tests/asts/test_default_events_ttl.yml
@@ -1,0 +1,34 @@
+- RuleSet:
+    default_events_ttl: 16 seconds
+    hosts:
+    - all
+    name: Evict events which are partially matched
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: print_event
+            action_args:
+              pretty: true
+        condition:
+          AllCondition:
+          - GreaterThanOrEqualToExpression:
+              lhs:
+                Event: i
+              rhs:
+                Integer: 0
+          - GreaterThanExpression:
+              lhs:
+                Event: x
+              rhs:
+                Integer: 34
+        enabled: true
+        name: r1
+    sources:
+    - EventSource:
+        name: range
+        source_args:
+          delay: 720
+          limit: 2
+        source_filters: []
+        source_name: range

--- a/tests/asts/test_stats.yml
+++ b/tests/asts/test_stats.yml
@@ -1,0 +1,50 @@
+- RuleSet:
+    hosts:
+    - localhost
+    name: Test Stats
+    rules:
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args:
+              events_event: '{{events.first}}'
+        condition:
+          AllCondition:
+          - AssignmentExpression:
+              lhs:
+                Events: first
+              rhs:
+                EqualsExpression:
+                  lhs:
+                    Event: i
+                  rhs:
+                    Integer: 67
+        enabled: true
+        name: assignment
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args:
+              events_event: '{{events.first}}'
+        condition:
+          AllCondition:
+          - AssignmentExpression:
+              lhs:
+                Events: first
+              rhs:
+                EqualsExpression:
+                  lhs:
+                    Event: i
+                  rhs:
+                    Integer: 67
+        enabled: false
+        name: disabled1
+    sources:
+    - EventSource:
+        name: range
+        source_args:
+          limit: 5
+        source_filters: []
+        source_name: range


### PR DESCRIPTION
Added support for partial matches
Added support for default_events_ttl which allows partial events to be evicted from memory after a user defined default or the system default (2 hours) if missing
Get Session Stats