### PR TITLE
Added support for complete match on retract fact

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -266,6 +266,33 @@ def test_retract_matching_facts():
     assert len(response) == 0
 
 
+def test_retract_matching_facts_complete():
+    test_data = load_ast("asts/retract_matching_facts.yml")
+
+    my_callback1 = mock.Mock()
+    my_callback2 = mock.Mock()
+    result = Matches(data={"m": {"meta": {"uuid": "934"}, "i": 67, "n": 239}})
+
+    ruleset_data = test_data[0]["RuleSet"]
+    rs = Ruleset(
+        name=ruleset_data["name"], serialized_ruleset=json.dumps(ruleset_data)
+    )
+    rs.add_rule(Rule("r1", my_callback1))
+    rs.add_rule(Rule("r2", my_callback2))
+
+    rs.assert_fact(json.dumps(dict(i=67, n=239, meta=dict(uuid="934"))))
+    rs.assert_fact(json.dumps(dict(j=42)))
+    assert not my_callback1.called
+
+    assert (len(rs.get_facts())) == 1
+    rs.retract_matching_facts(json.dumps(dict(i=67, n=239)), True, ["meta"])
+
+    my_callback2.assert_called_with(result)
+    response = rs.get_facts()
+    rs.end_session()
+    assert len(response) == 0
+
+
 def test_get_facts():
     test_data = load_ast("asts/assert_fact.yml")
 


### PR DESCRIPTION
When retracting a fact we should be able to specify either partial or complete facts. The default is partial since events can be huge and it might not be practical to specify the whole fact. But in some cases when the event is small they might want to do a complete match, but exclude any system added keys like meta.

https://issues.redhat.com/browse/AAP-11109