### PR TITLE
DROOLS-7475 Proposed feature for ['key'] accessor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]
@@ -44,8 +44,8 @@ dev = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/mkanoor/drools_jpy"
-"Bug Tracker" = "https://github.com/mkanoor/drools_jpy/issues"
+"Homepage" = "https://github.com/ansible/drools_jpy"
+"Bug Tracker" = "https://github.com/ansible/drools_jpy/issues"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/asts/test_squaredaccessor_ast.yml
+++ b/tests/asts/test_squaredaccessor_ast.yml
@@ -1,0 +1,96 @@
+- RuleSet:
+    hosts:
+    - all
+    name: test squared accessor
+    rules:
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Fact: range['pi']
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: r1
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Fact: range["pi"]
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: r2
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Fact: range["pi"].value
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: r3
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Fact: range[0]
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: r4
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Fact: range[-1]
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: r5
+    - Rule:
+        action:
+          Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Fact: range["x"][1][2].a["b"]
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: r6
+    sources:
+    - EventSource:
+        name: range
+        source_args:
+          limit: 5
+        source_filters: []
+        source_name: range

--- a/tests/asts/test_squaredaccessor_cases_ast.yml
+++ b/tests/asts/test_squaredaccessor_cases_ast.yml
@@ -1,0 +1,35 @@
+- RuleSet:
+    hosts:
+    - all
+    name: Test squared accessor
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: debug
+            action_args:
+              msg: 'Testcase #1 passes'
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Event: asd["x"][1][2].a["b"]
+              rhs:
+                Float: 3.1415
+        enabled: true
+        name: 'r1 squared accessor'
+    sources:
+    - EventSource:
+        name: generic
+        source_args:
+          payload:
+          - asd:
+              x:
+              - 0
+              - - 0
+                - 0
+                - a:
+                    b: 3.1415
+            id: 'Testcase #1'
+        source_filters: []
+        source_name: generic

--- a/tests/asts/test_squaredaccessor_selectattr_cases_ast.yml
+++ b/tests/asts/test_squaredaccessor_selectattr_cases_ast.yml
@@ -1,0 +1,40 @@
+- RuleSet:
+    hosts:
+    - all
+    name: Test squared accessor with selectattr operator
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: debug
+            action_args:
+              msg: Output for testcase
+        condition:
+          AllCondition:
+          - SelectAttrExpression:
+              lhs:
+                Event: asd["x"][1][2].a
+              rhs:
+                key:
+                  String: b
+                operator:
+                  String: ==
+                value:
+                  Float: 3.1415
+        enabled: true
+        name: r1 selectattr and squared accessor interaction
+    sources:
+    - EventSource:
+        name: generic
+        source_args:
+          payload:
+          - asd:
+              x:
+              - 0
+              - - 0
+                - 0
+                - a:
+                    b: 3.1415
+            id: 'Testcase #1'
+        source_filters: []
+        source_name: generic

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -94,6 +94,53 @@ def test_assert_multiple_facts():
     my_callback2.assert_called_with(result2)
 
 
+def test_squared_accessors():
+    test_data = load_ast("asts/test_squaredaccessor_ast.yml")
+
+    my_callback1 = mock.Mock()
+    my_callback2 = mock.Mock()
+    my_callback3 = mock.Mock()
+    my_callback4 = mock.Mock()
+    my_callback5 = mock.Mock()
+    my_callback6 = mock.Mock()
+    result1_and_2 = Matches(
+        data={"m": {"id":"A", "range":{"pi": 3.1415}}}
+    )
+    result3 = Matches(
+        data={"m": {"id":"B", "range":{"pi": {"value":3.1415}}}}
+    )
+    result4_and_5 = Matches(
+        data={"m": {"id":"C", "range":[3.1415]}}
+    )
+    result6 = Matches(
+        data={"m": {"id":"D", "range":{"x": [0, [0, 0, {"a":{"b": 3.1415}}]]}}}
+    )
+
+    ruleset_data = test_data[0]["RuleSet"]
+    rs = Ruleset(
+        name=ruleset_data["name"], serialized_ruleset=json.dumps(ruleset_data)
+    )
+    rs.add_rule(Rule("r1", my_callback1))
+    rs.add_rule(Rule("r2", my_callback2))
+    rs.add_rule(Rule("r3", my_callback3))
+    rs.add_rule(Rule("r4", my_callback4))
+    rs.add_rule(Rule("r5", my_callback5))
+    rs.add_rule(Rule("r6", my_callback6))
+
+    rs.assert_fact(json.dumps({"id":"A", "range":{"pi": 3.1415}}))
+    rs.assert_fact(json.dumps({"id":"B", "range":{"pi": {"value":3.1415}}}))
+    rs.assert_fact(json.dumps({"id":"C", "range":[3.1415]}))
+    rs.assert_fact(json.dumps({"id":"D", "range":{"x": [0, [0, 0, {"a":{"b": 3.1415}}]]}}))
+
+    rs.end_session()
+    my_callback1.assert_called_with(result1_and_2)
+    my_callback2.assert_called_with(result1_and_2)
+    my_callback3.assert_called_with(result3)
+    my_callback4.assert_called_with(result4_and_5)
+    my_callback5.assert_called_with(result4_and_5)
+    my_callback6.assert_called_with(result6)
+
+
 def test_multiple_rulesets():
     test_data = load_ast("asts/multiple_rule_ast.yml")
     fired_callbacks = []

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -103,17 +103,15 @@ def test_squared_accessors():
     my_callback4 = mock.Mock()
     my_callback5 = mock.Mock()
     my_callback6 = mock.Mock()
-    result1_and_2 = Matches(
-        data={"m": {"id":"A", "range":{"pi": 3.1415}}}
-    )
+    result1_and_2 = Matches(data={"m": {"id": "A", "range": {"pi": 3.1415}}})
     result3 = Matches(
-        data={"m": {"id":"B", "range":{"pi": {"value":3.1415}}}}
+        data={"m": {"id": "B", "range": {"pi": {"value": 3.1415}}}}
     )
-    result4_and_5 = Matches(
-        data={"m": {"id":"C", "range":[3.1415]}}
-    )
+    result4_and_5 = Matches(data={"m": {"id": "C", "range": [3.1415]}})
     result6 = Matches(
-        data={"m": {"id":"D", "range":{"x": [0, [0, 0, {"a":{"b": 3.1415}}]]}}}
+        data={
+            "m": {"id": "D", "range": {"x": [0, [0, 0, {"a": {"b": 3.1415}}]]}}
+        }
     )
 
     ruleset_data = test_data[0]["RuleSet"]
@@ -127,10 +125,14 @@ def test_squared_accessors():
     rs.add_rule(Rule("r5", my_callback5))
     rs.add_rule(Rule("r6", my_callback6))
 
-    rs.assert_fact(json.dumps({"id":"A", "range":{"pi": 3.1415}}))
-    rs.assert_fact(json.dumps({"id":"B", "range":{"pi": {"value":3.1415}}}))
-    rs.assert_fact(json.dumps({"id":"C", "range":[3.1415]}))
-    rs.assert_fact(json.dumps({"id":"D", "range":{"x": [0, [0, 0, {"a":{"b": 3.1415}}]]}}))
+    rs.assert_fact(json.dumps({"id": "A", "range": {"pi": 3.1415}}))
+    rs.assert_fact(json.dumps({"id": "B", "range": {"pi": {"value": 3.1415}}}))
+    rs.assert_fact(json.dumps({"id": "C", "range": [3.1415]}))
+    rs.assert_fact(
+        json.dumps(
+            {"id": "D", "range": {"x": [0, [0, 0, {"a": {"b": 3.1415}}]]}}
+        )
+    )
 
     rs.end_session()
     my_callback1.assert_called_with(result1_and_2)

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -982,6 +982,8 @@ def test_assert_event_string_search():
         "asts/test_select_with_same_event_ast.yml",
         "asts/test_self_referential_ast.yml",
         "asts/test_delayed_comparison_ast.yml",
+        "asts/test_squaredaccessor_cases_ast.yml",
+        "asts/test_squaredaccessor_selectattr_cases_ast.yml",
     ],
 )
 def test_integrated(rulebook):


### PR DESCRIPTION
- updated with the new jar
- test using the AST JSON for drools-jpy (see [tests in here](https://github.com/ansible/ansible-rulebook/pull/539/files#diff-4cf5f03ca6d7c98631ca262df423d16cfaac677daaee66ca6a59e4a2c387eed2)) but working with new version of jar of `drools-ansible-rulebook-integration` (using [this version](https://github.com/kiegroup/drools-ansible-rulebook-integration/releases/tag/latest) at the time of writing/raising this PR)

**JIRA**: https://issues.redhat.com/browse/DROOLS-7475

**referenced Pull Requests**: 

* https://github.com/ansible/ansible-rulebook/pull/539
* https://github.com/ansible/drools_jpy/pull/50
* https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/56
* https://github.com/kiegroup/drools/pull/5333