### PR TITLE
AAP-10738 DROOLS-7475 fix idx for ['key'] accessor in once_after

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]


### PR DESCRIPTION
incorporates fix from:
 - https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/65

relates to:
 - https://github.com/ansible/ansible-rulebook/pull/539