### PR TITLE
upstream drools-ansible-rulebook-integration Update to JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This python package allows you to directly call Drools classes (implemented in Java) using JPY from your Python code.
 Needs
-   * Java 11+
+   * Java 17+
    * Maven 3.8.1+
    * Environment variable **JAVA_HOME** should be set appropriately
 


### PR DESCRIPTION
Related PRs:

- https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/68
- https://github.com/ansible/drools_jpy/pull/52
- https://github.com/kiegroup/drools/pull/5417