### PR TITLE
chore: new version 0.3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drools_jpy"
-version = "0.3.11"
+version = "0.3.12"
 authors = [
   { name="Madhu Kanoor", email="author@example.com" },
 ]


### PR DESCRIPTION
I messed up the 0.3.11 it had an incorrect jar.
Bumping to a newer version