### PR TITLE
feat: add support for accumulate_within and threshold

### DIFF
--- a/tests/asts/test_accumulate_within_ast.yml
+++ b/tests/asts/test_accumulate_within_ast.yml
@@ -1,0 +1,46 @@
+- RuleSet:
+    hosts:
+    - localhost
+    name: Test accumulate within
+    rules:
+    - Rule:
+        actions:
+        - Action:
+            action: debug
+            action_args: {}
+        condition:
+          AllCondition:
+          - EqualsExpression:
+              lhs:
+                Event: level
+              rhs:
+                String: error
+        enabled: true
+        name: r1
+        throttle:
+          accumulate_within: 5 minutes
+          group_by_attributes:
+          - event.level
+          - event.code
+          threshold: 3
+    sources:
+    - EventSource:
+        name: Test
+        source_args:
+          event_delay: 60
+          loop_delay: 30
+          payload:
+          - code: 205
+            level: error
+            name: alert1
+          - code: 207
+            level: warning
+            name: alert2
+          - code: 205
+            level: error
+            name: alert3
+          - code: 205
+            level: error
+            name: alert11
+        source_filters: []
+        source_name: ansible.eda.generic


### PR DESCRIPTION
https://issues.redhat.com/browse/AAPRFE-12631

Drools now supports checking number of events that occur with in a time window. The event count can be specified in threshold.

e.g.
```
rules:
    - name: Throttle with threshold
      condition: event.level == 'error'
      throttle:
          accumulate_within: 1 minutes
          threshold: 3
          group_by_attributes:
             - event.level
             - event.code
      action:
        debug:
```