### PR TITLE
ci: extend Java testing with 17 & 21 with py3.12

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -12,15 +12,21 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        java-version: [ "18" ]
+        include:
+          - python-version: "3.12"
+            java-version: "17"
+          - python-version: "3.12"
+            java-version: "21"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Install Java 
+      - name: Install Java ${{ matrix.java-version }}
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '18'
+          java-version: ${{ matrix.java-version }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Make it possible to test multiple versions of Java rather than only 18. To avoid testing every Java version with every Python version, only Python 3.12 is used for testing different Java versions, keeping only 18 for other Python versions.

Also add:
- Java 17: the LTS currently in use by ansible-rulebook
- Java 21: supported by drools-ansible-integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Expanded the CI test matrix to run against additional Java versions, with a default Java 18 configuration and extra combinations alongside Python 3.12.
  * Updated the Java setup process to use the selected matrix Java version, improving consistency across CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->